### PR TITLE
Fix/redirect post blog language

### DIFF
--- a/apps/web/app/404/page.js
+++ b/apps/web/app/404/page.js
@@ -1,4 +1,10 @@
 /* eslint-disable @next/next/no-html-link-for-pages */
+
+export const metadata = {
+  title: 'Página no encontrada | Fresh Food Panamá',
+  description: 'La página que buscas no existe. Volver al inicio de Fresh Food Panamá.',
+};
+
 export default function NotFound404() {
   return (
     <div style={{ display: 'flex', minHeight: '100vh', alignItems: 'center', justifyContent: 'center' }}>

--- a/apps/web/app/404/page.js
+++ b/apps/web/app/404/page.js
@@ -1,5 +1,5 @@
 /* eslint-disable @next/next/no-html-link-for-pages */
-export default function NotFound() {
+export default function NotFound404() {
   return (
     <div style={{ display: 'flex', minHeight: '100vh', alignItems: 'center', justifyContent: 'center' }}>
       <div style={{ textAlign: 'center' }}>
@@ -14,7 +14,7 @@ export default function NotFound() {
             backgroundColor: '#16a34a',
             color: 'white',
             borderRadius: '9999px',
-            textDecoration: 'none'
+            textDecoration: 'none',
           }}
         >
           Volver al inicio

--- a/apps/web/app/[locale]/blog/[slug]/page.js
+++ b/apps/web/app/[locale]/blog/[slug]/page.js
@@ -16,19 +16,30 @@ async function getPost(slug, language) {
 export async function generateMetadata({ params }) {
   const { slug, locale } = await params;
 
+  const defaultDescription =
+    locale === 'es'
+      ? 'Artículos sobre exportación de frutas tropicales, agricultura sostenible y productos frescos desde Panamá.'
+      : 'Articles about tropical fruit export, sustainable agriculture and fresh products from Panama.';
+
   if (!checkSanityConfig()) {
-    return { title: 'Blog | Fresh Food' };
+    return {
+      title: 'Blog | Fresh Food',
+      description: defaultDescription,
+    };
   }
 
   const post = await getPost(slug, locale);
 
   if (!post) {
-    return { title: 'Post no encontrado' };
+    return {
+      title: locale === 'es' ? 'Post no encontrado' : 'Post not found',
+      description: defaultDescription,
+    };
   }
 
   return {
     title: `${post.title} | Fresh Food Blog`,
-    description: post.excerpt,
+    description: post.excerpt || defaultDescription,
   };
 }
 

--- a/apps/web/app/[locale]/blog/[slug]/page.js
+++ b/apps/web/app/[locale]/blog/[slug]/page.js
@@ -9,8 +9,8 @@ import GeneralLayout from '@/components/general-layout/general-layout';
 import { getDictionary } from '@/lib/getDictionary';
 import { IoArrowForwardCircleOutline, IoArrowForwardOutline } from 'react-icons/io5';
 
-async function getPost(slug) {
-  return await safeFetch(postBySlugQuery, { slug });
+async function getPost(slug, language) {
+  return await safeFetch(postBySlugQuery, { slug, language });
 }
 
 export async function generateMetadata({ params }) {
@@ -20,7 +20,7 @@ export async function generateMetadata({ params }) {
     return { title: 'Blog | Fresh Food' };
   }
 
-  const post = await getPost(slug);
+  const post = await getPost(slug, locale);
 
   if (!post) {
     return { title: 'Post no encontrado' };
@@ -54,7 +54,7 @@ export default async function PostPage({ params }) {
     );
   }
 
-  const post = await getPost(slug);
+  const post = await getPost(slug, locale);
 
   if (!post) {
     notFound();

--- a/apps/web/app/[locale]/blog/[slug]/page.js
+++ b/apps/web/app/[locale]/blog/[slug]/page.js
@@ -60,9 +60,23 @@ export default async function PostPage({ params }) {
     notFound();
   }
 
+  // Construir URLs alternativas para el language switcher (slugs pueden diferir por idioma)
+  const alternateUrls = (post._translations || [])
+    .filter((t) => t?.slug && t?.language)
+    .reduce(
+      (acc, t) => {
+        acc[t.language] = `/${t.language}/blog/${t.slug}`;
+        return acc;
+      },
+      { es: null, en: null }
+    );
+  // Si falta una traducción, usar el índice del blog en ese idioma
+  if (!alternateUrls.es) alternateUrls.es = '/es/blog';
+  if (!alternateUrls.en) alternateUrls.en = '/en/blog';
+
   return (
     <div className="responsiveWidth mb-20 flex w-full flex-col px-5 text-greendark md:px-0">
-      <GeneralLayout dictionary={dictionary}>
+      <GeneralLayout dictionary={dictionary} alternateUrls={alternateUrls}>
         <section className="flex w-full flex-col items-center justify-center text-gray-800">
           <article className="mx-auto mt-20 max-w-3xl">
             {/* Breadcrumb */}

--- a/apps/web/app/[locale]/blog/[slug]/page.js
+++ b/apps/web/app/[locale]/blog/[slug]/page.js
@@ -1,5 +1,4 @@
-import { safeFetch, checkSanityConfig } from '@/sanity/lib/client';
-import { postBySlugQuery } from '@/sanity/lib/queries';
+import { checkSanityConfig } from '@/sanity/lib/client';
 import { urlFor } from '@/sanity/lib/image';
 import BlogContent from '@/components/blog/BlogContent';
 import Image from 'next/image';
@@ -7,11 +6,8 @@ import Link from 'next/link';
 import { notFound } from 'next/navigation';
 import GeneralLayout from '@/components/general-layout/general-layout';
 import { getDictionary } from '@/lib/getDictionary';
+import { resolveBlogPost } from '@/lib/resolveBlogPost';
 import { IoArrowForwardCircleOutline, IoArrowForwardOutline } from 'react-icons/io5';
-
-async function getPost(slug, language) {
-  return await safeFetch(postBySlugQuery, { slug, language });
-}
 
 export async function generateMetadata({ params }) {
   const { slug, locale } = await params;
@@ -28,7 +24,7 @@ export async function generateMetadata({ params }) {
     };
   }
 
-  const post = await getPost(slug, locale);
+  const post = await resolveBlogPost(slug, locale);
 
   if (!post) {
     return {
@@ -65,7 +61,7 @@ export default async function PostPage({ params }) {
     );
   }
 
-  const post = await getPost(slug, locale);
+  const post = await resolveBlogPost(slug, locale);
 
   if (!post) {
     notFound();

--- a/apps/web/app/[locale]/blog/page.js
+++ b/apps/web/app/[locale]/blog/page.js
@@ -49,7 +49,7 @@ const BlogPage = async ({ params }) => {
 
   return (
     <div className="responsiveWidth mb-20 flex w-full flex-col px-5 text-greendark md:px-0">
-      <GeneralLayout dictionary={dictionary}>
+      <GeneralLayout dictionary={dictionary} useScrollSmoother>
         <section className="flex w-full flex-col items-start justify-between gap-5 pb-10 md:h-[calc(100vh-130px)]">
           <BlogHero image="/img/frutas_blog_header.webp" brightness="0.6" yOffset={30}>
             <div className="relative z-10 mb-10 flex h-[450px] w-full flex-col items-start justify-center p-10 md:w-1/2 md:p-20">

--- a/apps/web/app/[locale]/blog/page.js
+++ b/apps/web/app/[locale]/blog/page.js
@@ -5,6 +5,7 @@ import { getDictionary } from '@/lib/getDictionary';
 import PostCard from 'components/post-card/post-card';
 import PostFeaturedCard from 'components/post-featured-card/post-featured-card';
 import BlogHero from 'components/blog-hero/blog-hero';
+import { TextAnimate } from '@/components/text-animate';
 
 async function getFeaturedPosts(language) {
   return await safeFetch(featuredPostsQuery, { language });
@@ -48,14 +49,20 @@ const BlogPage = async ({ params }) => {
   const posts = await getAllPosts(locale);
 
   return (
-    <div className="responsiveWidth mb-20 flex w-full flex-col px-5 text-greendark md:px-0">
+    <div className="responsiveWidth flex w-full flex-col px-5 text-greendark md:px-0">
       <GeneralLayout dictionary={dictionary} useScrollSmoother>
         <section className="flex w-full flex-col items-start justify-between gap-5 pb-10 md:h-[calc(100vh-130px)]">
-          <BlogHero image="/img/frutas_blog_header.webp" brightness="0.6" yOffset={30}>
+          <BlogHero image="/img/frutas_blog_header.webp" brightness="0.6" yOffset={20}>
             <div className="relative z-10 mb-10 flex h-[450px] w-full flex-col items-start justify-center p-10 md:w-1/2 md:p-20">
-              <p className="mb-10 rounded-full border border-white px-6 py-2 text-sm text-white">{dictionary.blog.PRODUCTS}</p>
-              <h1 className="text-2xl font-bold text-white md:text-4xl">{dictionary.blog.EXPERT_FARMERS}</h1>
-              <h2 className="font-thin text-lg text-white md:text-3xl">{dictionary.blog.BRINGING_THE_BEST_TO_WHERE_IT_MATTERS_MOST}</h2>
+              <TextAnimate from={{ opacity: 0, y: 50 }} duration={1.3} delay={0.2} once={false}>
+                <p className="mb-10 rounded-full border border-white px-6 py-2 text-sm text-white">{dictionary.blog.PRODUCTS}</p>
+              </TextAnimate>
+              <TextAnimate from={{ opacity: 0, y: 40 }} duration={1.3} delay={0.4} once={false}>
+                <h1 className="text-2xl font-bold text-white md:text-4xl">{dictionary.blog.EXPERT_FARMERS}</h1>
+              </TextAnimate>
+              <TextAnimate from={{ opacity: 0, y: 30 }} duration={1.3} delay={0.6} once={false}>
+                <h2 className="font-thin text-lg text-white md:text-3xl">{dictionary.blog.BRINGING_THE_BEST_TO_WHERE_IT_MATTERS_MOST}</h2>
+              </TextAnimate>
             </div>
           </BlogHero>
           <div className="grid w-full grow flex-col items-start justify-center gap-5 md:grid-cols-2">

--- a/apps/web/app/[locale]/blog/page.js
+++ b/apps/web/app/[locale]/blog/page.js
@@ -52,10 +52,10 @@ const BlogPage = async ({ params }) => {
       <GeneralLayout dictionary={dictionary}>
         <section className="flex w-full flex-col items-start justify-between gap-5 pb-10 md:h-[calc(100vh-130px)]">
           <BlogHero image="/img/frutas_blog_header.webp" brightness="0.6" yOffset={30}>
-            <div className="relative z-10 mb-10 flex w-1/2 flex-col items-start justify-center p-10 md:p-20">
-              <p className="mb-5 rounded-full border border-white px-6 py-2 text-sm text-white">{dictionary.blog.PRODUCTS}</p>
-              <h1 className="text-4xl font-bold text-white">{dictionary.blog.EXPERT_FARMERS}</h1>
-              <h2 className="font-thin text-3xl text-white">{dictionary.blog.BRINGING_THE_BEST_TO_WHERE_IT_MATTERS_MOST}</h2>
+            <div className="relative z-10 mb-10 flex h-[450px] w-full flex-col items-start justify-center p-10 md:w-1/2 md:p-20">
+              <p className="mb-10 rounded-full border border-white px-6 py-2 text-sm text-white">{dictionary.blog.PRODUCTS}</p>
+              <h1 className="text-2xl font-bold text-white md:text-4xl">{dictionary.blog.EXPERT_FARMERS}</h1>
+              <h2 className="font-thin text-lg text-white md:text-3xl">{dictionary.blog.BRINGING_THE_BEST_TO_WHERE_IT_MATTERS_MOST}</h2>
             </div>
           </BlogHero>
           <div className="grid w-full grow flex-col items-start justify-center gap-5 md:grid-cols-2">

--- a/apps/web/app/[locale]/page.js
+++ b/apps/web/app/[locale]/page.js
@@ -1,5 +1,5 @@
 import GeneralLayout from '@/components/general-layout/general-layout';
-import ScrollReveal from '@/components/scroll-reveal';
+import { ScrollReveal } from '@/components/scroll-reveal';
 import Image from 'next/image';
 import { TiLeaf } from 'react-icons/ti';
 import { BiWorld, BiLoaderCircle } from 'react-icons/bi';

--- a/apps/web/app/[locale]/page.js
+++ b/apps/web/app/[locale]/page.js
@@ -24,21 +24,29 @@ export default async function Home({ params }) {
       title: dictionary.home.compromise_items[0].TITLE,
       icon: <TiLeaf size={60} />,
       text: dictionary.home.compromise_items[0].TEXT,
+      start: 'top 80%',
+      delay: 1,
     },
     {
       title: dictionary.home.compromise_items[1].TITLE,
       icon: <BiWorld size={60} />,
       text: dictionary.home.compromise_items[1].TEXT,
+      start: 'top 85%',
+      delay: 0.5,
     },
     {
       title: dictionary.home.compromise_items[2].TITLE,
       icon: <BiLoaderCircle size={60} />,
       text: dictionary.home.compromise_items[2].TEXT,
+      start: 'top 76%',
+      delay: 0.7,
     },
     {
       title: dictionary.home.compromise_items[3].TITLE,
       icon: <LuBadgeCheck size={60} />,
       text: dictionary.home.compromise_items[3].TEXT,
+      start: 'top 75%',
+      delay: 0.8,
     },
   ];
 
@@ -47,41 +55,57 @@ export default async function Home({ params }) {
       title: dictionary.home.road_fruit_map[0].TITLE,
       icon: <PiFarmFill size={60} />,
       text: dictionary.home.road_fruit_map[0].TEXT,
+      start: 'top 80%',
+      delay: 0.5,
     },
     {
       title: dictionary.home.road_fruit_map[1].TITLE,
       icon: <FaTruckField size={60} />,
       text: dictionary.home.road_fruit_map[1].TEXT,
+      start: 'top 90%',
+      delay: 1,
     },
     {
       title: dictionary.home.road_fruit_map[2].TITLE,
       icon: <FaBoxesPacking size={60} />,
       text: dictionary.home.road_fruit_map[2].TEXT,
+      start: 'top 80%',
+      delay: 1.5,
     },
     {
       title: dictionary.home.road_fruit_map[3].TITLE,
       icon: <FaTruckLoading size={60} />,
       text: dictionary.home.road_fruit_map[3].TEXT,
+      start: 'top 85%',
+      delay: 1.0,
     },
     {
       title: dictionary.home.road_fruit_map[4].TITLE,
       icon: <PiShippingContainerFill size={60} />,
       text: dictionary.home.road_fruit_map[4].TEXT,
+      start: 'top 80%',
+      delay: 0.6,
     },
     {
       title: dictionary.home.road_fruit_map[5].TITLE,
       icon: <FaShip size={60} />,
       text: dictionary.home.road_fruit_map[5].TEXT,
+      start: 'top 90%',
+      delay: 0.75,
     },
     {
       title: dictionary.home.road_fruit_map[6].TITLE,
       icon: <MdHouseboat size={60} />,
       text: dictionary.home.road_fruit_map[6].TEXT,
+      start: 'top 85%',
+      delay: 0.9,
     },
     {
       title: dictionary.home.road_fruit_map[7].TITLE,
       icon: <FaTruckArrowRight size={60} className="" />,
       text: dictionary.home.road_fruit_map[7].TEXT,
+      start: 'top 80%',
+      delay: 0.5,
     },
   ];
 
@@ -116,8 +140,8 @@ export default async function Home({ params }) {
                 </TextAnimate>
               </div>
             </div>
-            {/* Imagen centrada en la sección completa para mantener tamaño 800px sin restricción de columna */}
-            <div className="pointer-events-none absolute left-1/2 top-1/2 z-10 -translate-x-1/2 -translate-y-1/2">
+
+            <div className="pointer-events-none absolute left-1/2 top-1/2 z-10 w-[90vw] -translate-x-1/2 -translate-y-1/2 md:w-auto">
               <ParallaxImage
                 src="/img/frutas_con_zumo_ok.webp"
                 alt="frutas con zumo"
@@ -125,7 +149,10 @@ export default async function Home({ params }) {
                 speed={0.1}
                 height={200}
                 fill={false}
-                imageClassName="mb-0 md:mb-28 md:h-auto md:w-[800px]"
+                fadeIn
+                zoomIn
+                className="w-full md:w-auto"
+                imageClassName="mb-0 w-full md:mb-28 h-auto md:w-[800px] w-auto"
                 priority
                 quality={90}
               />
@@ -133,44 +160,22 @@ export default async function Home({ params }) {
           </section>
 
           <BlogHero image="/img/agricultor_limones_tahiti_ok.webp" brightness="0.9" isCover={false}>
-            <div className="relative z-10 flex h-full w-full items-center justify-center gap-5 p-10 md:h-[calc(100vh-130px)] md:p-16">
+            <div className="relative z-10 flex h-[400px] w-full items-center justify-center gap-5 p-10 md:h-[calc(100vh-130px)] md:p-16">
               <div className="flex w-1/2 flex-col items-start justify-center">
-                <h2 className="font-black text-l-200 leading-snug text-white md:text-l-500">{dictionary.home.AGRICULTORES_EXPERTOS}</h2>
-                <p className="font-reg text-l-200 text-white md:text-l-500" dangerouslySetInnerHTML={{ __html: dictionary.home.LLEVANDO_TU_MESA }} />
+                <ScrollReveal start="top 80%" duration={1.5} once={false}>
+                  <h2 className="font-black text-l-200 leading-snug text-white md:text-l-500">{dictionary.home.AGRICULTORES_EXPERTOS}</h2>
+                </ScrollReveal>
+                <ScrollReveal start="top 80%" once={false}>
+                  <p
+                    className="font-reg text-l-200 text-white md:text-l-500"
+                    dangerouslySetInnerHTML={{ __html: dictionary.home.LLEVANDO_TU_MESA }}
+                  />
+                </ScrollReveal>
               </div>
               <div className="flex w-1/2 flex-col items-center justify-center" />
             </div>
           </BlogHero>
 
-          {/* <section
-            className="relative mt-0 flex w-full rounded-2xl bg-cover bg-center bg-no-repeat md:mt-28 md:h-[calc(100vh-130px)] md:rounded-[50px] md:pt-[56.25%]"
-            style={{
-              backgroundImage: 'url(/img/agricultor_limones_tahiti_ok.webp)',
-            }}
-          >
-            <div
-              style={{
-                position: 'absolute',
-                top: 0,
-                left: 0,
-                right: 0,
-                bottom: 0,
-                borderRadius: '50px',
-                background: 'linear-gradient(90deg,rgba(0, 0, 0, 0.60) 0%, rgba(255, 255, 255, 0) 50%, rgba(255, 255, 255, 0) 100%)',
-              }}
-            >
-              <div className="flex h-full w-full items-center justify-center gap-5 p-10 md:p-16">
-                <div className="flex w-1/2 flex-col items-start justify-center">
-                  <h2 className="font-black text-l-200 leading-snug text-white md:text-l-500">{dictionary.home.AGRICULTORES_EXPERTOS}</h2>
-                  <p
-                    className="font-reg text-l-200 text-white md:text-l-500"
-                    dangerouslySetInnerHTML={{ __html: dictionary.home.LLEVANDO_TU_MESA }}
-                  />
-                </div>
-                <div className="flex w-1/2 flex-col items-center justify-center" />
-              </div>
-            </div>
-          </section> */}
           <section className="flex w-full flex-col items-start justify-center text-greendark md:mt-14">
             <h2
               className="font-black text-l-500 text-greendark md:text-l-600"
@@ -179,37 +184,45 @@ export default async function Home({ params }) {
             <div className="mt-10 grid w-full grid-cols-1 gap-10 md:grid-cols-4 md:gap-10">
               {compromiseItems.map((item, key) => {
                 return (
-                  <div key={key} className="flex w-full flex-col items-center justify-start gap-2 p-0 md:gap-5 md:p-5">
-                    <div className="flex w-full items-center justify-start">{item.icon}</div>
-                    <div className="flex w-full flex-col items-start justify-start gap-2">
-                      <p className="leading-2 font-black text-l-400 md:text-l-300">{item.title}</p>
-                      <p className="text-l-200">{item.text}</p>
+                  <ScrollReveal key={key} start={item.start} from={{ opacity: 0, y: 50 }} duration={1.2} delay={item.delay} once={false}>
+                    <div key={key} className="flex w-full flex-col items-center justify-start gap-2 p-0 md:gap-5 md:p-5">
+                      <div className="flex w-full items-center justify-start">{item.icon}</div>
+                      <div className="flex w-full flex-col items-start justify-start gap-2">
+                        <p className="leading-2 font-black text-l-400 md:text-l-300">{item.title}</p>
+                        <p className="text-l-200">{item.text}</p>
+                      </div>
                     </div>
-                  </div>
+                  </ScrollReveal>
                 );
               })}
             </div>
           </section>
           <section className="flex w-full flex-col items-start justify-center gap-5 text-greendark md:mt-14">
             <div className="flex max-w-[350px] flex-col items-start justify-center gap-5">
-              <h2
-                className="font-black text-l-500 text-greendark md:text-l-600"
-                dangerouslySetInnerHTML={{ __html: dictionary.home.NUESTRO_EMPAQUE }}
-              />
+              <ScrollReveal start="top 80%" from={{ opacity: 0, y: 50 }} duration={1.2} delay={0.5} once={false}>
+                <h2
+                  className="font-black text-l-500 text-greendark md:text-l-600"
+                  dangerouslySetInnerHTML={{ __html: dictionary.home.NUESTRO_EMPAQUE }}
+                />
+              </ScrollReveal>
             </div>
             <div className="grid w-full grid-cols-1 gap-5 md:grid-cols-3">
               <div className="flex w-full items-center justify-center">
                 <Image src={'/img/mangos_box_ok.webp'} width={400} height={200} alt="mangos en caja" loading="lazy" quality={85} />
               </div>
               <div className="flex w-full flex-col items-center justify-center gap-5">
-                <p
-                  className="max-w-[350px] text-left font-reg text-l-600 leading-10 md:text-center"
-                  dangerouslySetInnerHTML={{ __html: dictionary.home.GARANTIZAMOS_SEGURIDAD_REQUERIMIENTOS }}
-                />
-                <p
-                  className="max-w-[350px] text-left text-l-300 md:text-center"
-                  dangerouslySetInnerHTML={{ __html: dictionary.home.UTILIZAMOS_MATERIAL_ALTA_CALIDAD }}
-                />
+                <ScrollReveal start="top 80%" from={{ opacity: 0, y: 50 }} duration={1.2} delay={0.5} once={false}>
+                  <p
+                    className="max-w-[350px] text-left font-reg text-l-600 leading-10 md:text-center"
+                    dangerouslySetInnerHTML={{ __html: dictionary.home.GARANTIZAMOS_SEGURIDAD_REQUERIMIENTOS }}
+                  />
+                </ScrollReveal>
+                <ScrollReveal start="top 80%" from={{ opacity: 0, y: 50 }} duration={1.8} delay={1} once={false}>
+                  <p
+                    className="max-w-[350px] text-left text-l-300 md:text-center"
+                    dangerouslySetInnerHTML={{ __html: dictionary.home.UTILIZAMOS_MATERIAL_ALTA_CALIDAD }}
+                  />
+                </ScrollReveal>
               </div>
               <div className="flex w-full items-center justify-center">
                 <Image src={'/img/pineapples_box_ok.webp'} width={400} height={200} alt="piñas en caja" loading="lazy" quality={85} />
@@ -221,16 +234,18 @@ export default async function Home({ params }) {
             <div className="mt-10 grid w-full grid-cols-1 gap-10 md:grid-cols-4">
               {RoadFruitMap.map((item, key) => {
                 return (
-                  <div key={key} className="flex w-full flex-col items-center justify-start gap-5 md:p-5">
-                    <div className="flex w-full items-center justify-start gap-3">
-                      <p className="font-black text-l-600">{key + 1}</p>
-                      {item.icon}
+                  <ScrollReveal key={key} start={item.start} from={{ opacity: 0, y: 50 }} duration={1.8} delay={item.delay} once={false}>
+                    <div className="flex w-full flex-col items-center justify-start gap-5 md:p-5">
+                      <div className="flex w-full items-center justify-start gap-3">
+                        <p className="font-black text-l-600">{key + 1}</p>
+                        {item.icon}
+                      </div>
+                      <div className="flex w-full flex-col items-start justify-start gap-2">
+                        <p className="font-black text-l-300">{item.title}</p>
+                        <p>{item.text}</p>
+                      </div>
                     </div>
-                    <div className="flex w-full flex-col items-start justify-start gap-2">
-                      <p className="font-black text-l-300">{item.title}</p>
-                      <p>{item.text}</p>
-                    </div>
-                  </div>
+                  </ScrollReveal>
                 );
               })}
             </div>

--- a/apps/web/app/[locale]/page.js
+++ b/apps/web/app/[locale]/page.js
@@ -1,4 +1,5 @@
 import GeneralLayout from '@/components/general-layout/general-layout';
+import ScrollReveal from '@/components/scroll-reveal';
 import Image from 'next/image';
 import { TiLeaf } from 'react-icons/ti';
 import { BiWorld, BiLoaderCircle } from 'react-icons/bi';
@@ -10,6 +11,9 @@ import { LuBadgeCheck } from 'react-icons/lu';
 import { FaTruckLoading } from 'react-icons/fa';
 import { getDictionary } from '@/lib/getDictionary';
 import Link from 'next/link';
+import { TextAnimate } from '@/components/text-animate';
+import { ParallaxImage } from '@/components/parallax';
+import BlogHero from 'components/blog-hero/blog-hero';
 
 export default async function Home({ params }) {
   const { locale } = await params;
@@ -82,43 +86,64 @@ export default async function Home({ params }) {
   ];
 
   return (
-    <div className="flex flex-col responsiveWidth">
+    <div className="responsiveWidth flex flex-col">
       <GeneralLayout dictionary={dictionary}>
-        <div className="flex flex-col gap-14 w-full items-center justify-center">
-          <section className="flex flex-col w-full h-full mt-10 md:mt-0 md:h-[calc(100vh-180px)] items-center justify-center gap-7">
-            <div className="flex flex-col md:flex-row items-center justify-center w-full h-full">
-              <div className="flex flex-col items-start md:items-end justify-center w-full md:w-2/6 text-greendark text-left md:text-right gap-5">
-                <h1 className="font-black text-l-600 md:text-l-800">{dictionary.home.LLEVAMOS_LA_FRUTA}</h1>
-                <p className="text-l-200 md:text-l-500">
-                  {dictionary.home.CADA_PRODUCTO_LLEGA}
-                  <span className="font-rare text-l-400 md:text-l-600 leading-3">{dictionary.home.BIEN_HECHO}</span>
-                </p>
+        <div className="flex w-full flex-col items-center justify-center gap-14">
+          <section className="relative mt-10 flex h-full w-full flex-col items-center justify-center gap-7 md:mt-0 md:h-[calc(100vh-180px)]">
+            <div className="flex h-full w-full flex-col items-center justify-center md:flex-row">
+              <div className="flex w-full flex-col items-start justify-center gap-5 text-left text-greendark md:w-2/6 md:items-end md:text-right">
+                <TextAnimate from={{ opacity: 0, y: 50 }} duration={0.8}>
+                  <h1 className="font-black text-l-600 md:text-l-800">{dictionary.home.LLEVAMOS_LA_FRUTA}</h1>
+                </TextAnimate>
+                <TextAnimate from={{ opacity: 0, y: 50 }} duration={0.9} delay={0.2}>
+                  <p className="text-l-200 md:text-l-500">
+                    {dictionary.home.CADA_PRODUCTO_LLEGA}
+                    <span className="font-rare text-l-400 leading-3 md:text-l-600">{dictionary.home.BIEN_HECHO}</span>
+                  </p>
+                </TextAnimate>
 
                 <Link
                   href={'/about-us'}
-                  className="flex justify-center px-10 py-3 bg-greendark rounded-full text-white z-20 hover:px-14 transition-all w-full md:w-fit"
+                  className="z-20 flex w-full justify-center rounded-full bg-greendark px-10 py-3 text-white transition-all hover:px-14 md:w-fit"
                 >
                   {dictionary.home.YA_NOS_CONOCES}
                 </Link>
               </div>
-              <div className="flex items-center justify-center w-full md:w-2/6 h-[100px] mt-44 md:mt-0">
-                <Image
-                  className="mb-0 md:mb-28 md:h-auto md:w-[800px] absolute z-10"
-                  src={'/img/frutas_con_zumo_ok.webp'}
-                  width={700}
-                  height={200}
-                  alt="frutas con zumo"
-                  priority
-                  quality={90}
-                />
-              </div>
-              <div className="flex flex-col items-start justify-center w-full md:w-2/6 h-ful gap-5">
-                <p className="font-black text-l-600 md:text-l-800 text-greendark">{dictionary.home.LIMON_MANGO}</p>
+              <div className="mt-44 flex h-[100px] w-full items-center justify-center md:mt-0 md:w-2/6" />
+              <div className="h-ful flex w-full flex-col items-start justify-center gap-5 md:w-2/6">
+                <TextAnimate from={{ opacity: 0, y: 50 }} duration={1.2} delay={0.5}>
+                  <p className="font-black text-l-600 text-greendark md:text-l-800">{dictionary.home.LIMON_MANGO}</p>
+                </TextAnimate>
               </div>
             </div>
+            {/* Imagen centrada en la sección completa para mantener tamaño 800px sin restricción de columna */}
+            <div className="pointer-events-none absolute left-1/2 top-1/2 z-10 -translate-x-1/2 -translate-y-1/2">
+              <ParallaxImage
+                src="/img/frutas_con_zumo_ok.webp"
+                alt="frutas con zumo"
+                width={700}
+                speed={0.1}
+                height={200}
+                fill={false}
+                imageClassName="mb-0 md:mb-28 md:h-auto md:w-[800px]"
+                priority
+                quality={90}
+              />
+            </div>
           </section>
-          <section
-            className="mt-0 md:mt-28 flex relative w-full md:pt-[56.25%] rounded-2xl md:rounded-[50px] bg-cover bg-center bg-no-repeat h-[400px] md:h-auto"
+
+          <BlogHero image="/img/agricultor_limones_tahiti_ok.webp" brightness="0.9" isCover={false}>
+            <div className="relative z-10 flex h-full w-full items-center justify-center gap-5 p-10 md:h-[calc(100vh-130px)] md:p-16">
+              <div className="flex w-1/2 flex-col items-start justify-center">
+                <h2 className="font-black text-l-200 leading-snug text-white md:text-l-500">{dictionary.home.AGRICULTORES_EXPERTOS}</h2>
+                <p className="font-reg text-l-200 text-white md:text-l-500" dangerouslySetInnerHTML={{ __html: dictionary.home.LLEVANDO_TU_MESA }} />
+              </div>
+              <div className="flex w-1/2 flex-col items-center justify-center" />
+            </div>
+          </BlogHero>
+
+          {/* <section
+            className="relative mt-0 flex w-full rounded-2xl bg-cover bg-center bg-no-repeat md:mt-28 md:h-[calc(100vh-130px)] md:rounded-[50px] md:pt-[56.25%]"
             style={{
               backgroundImage: 'url(/img/agricultor_limones_tahiti_ok.webp)',
             }}
@@ -134,27 +159,30 @@ export default async function Home({ params }) {
                 background: 'linear-gradient(90deg,rgba(0, 0, 0, 0.60) 0%, rgba(255, 255, 255, 0) 50%, rgba(255, 255, 255, 0) 100%)',
               }}
             >
-              <div className="flex items-center justify-center w-full gap-5 h-full p-10 md:p-16">
-                <div className="flex flex-col w-1/2 justify-center items-start">
-                  <h2 className="text-white leading-snug font-black text-l-200 md:text-l-500">{dictionary.home.AGRICULTORES_EXPERTOS}</h2>
+              <div className="flex h-full w-full items-center justify-center gap-5 p-10 md:p-16">
+                <div className="flex w-1/2 flex-col items-start justify-center">
+                  <h2 className="font-black text-l-200 leading-snug text-white md:text-l-500">{dictionary.home.AGRICULTORES_EXPERTOS}</h2>
                   <p
-                    className="text-white text-l-200 md:text-l-500 font-reg"
+                    className="font-reg text-l-200 text-white md:text-l-500"
                     dangerouslySetInnerHTML={{ __html: dictionary.home.LLEVANDO_TU_MESA }}
                   />
                 </div>
-                <div className="flex flex-col items-center justify-center w-1/2" />
+                <div className="flex w-1/2 flex-col items-center justify-center" />
               </div>
             </div>
-          </section>
-          <section className="flex flex-col items-start justify-center w-full md:mt-14 text-greendark">
-            <h2 className="font-black text-l-500 md:text-l-600 text-greendark" dangerouslySetInnerHTML={{ __html: dictionary.home.NUESTRO_COMPROMISO }} />
-            <div className="grid grid-cols-1 md:grid-cols-4 w-full gap-10 md:gap-10 mt-10">
+          </section> */}
+          <section className="flex w-full flex-col items-start justify-center text-greendark md:mt-14">
+            <h2
+              className="font-black text-l-500 text-greendark md:text-l-600"
+              dangerouslySetInnerHTML={{ __html: dictionary.home.NUESTRO_COMPROMISO }}
+            />
+            <div className="mt-10 grid w-full grid-cols-1 gap-10 md:grid-cols-4 md:gap-10">
               {compromiseItems.map((item, key) => {
                 return (
-                  <div key={key} className="flex w-full flex-col justify-start items-center p-0 md:p-5 gap-2 md:gap-5">
-                    <div className="flex items-center justify-start w-full">{item.icon}</div>
-                    <div className="flex flex-col items-start justify-start w-full gap-2">
-                      <p className="font-black text-l-400 md:text-l-300 leading-2">{item.title}</p>
+                  <div key={key} className="flex w-full flex-col items-center justify-start gap-2 p-0 md:gap-5 md:p-5">
+                    <div className="flex w-full items-center justify-start">{item.icon}</div>
+                    <div className="flex w-full flex-col items-start justify-start gap-2">
+                      <p className="leading-2 font-black text-l-400 md:text-l-300">{item.title}</p>
                       <p className="text-l-200">{item.text}</p>
                     </div>
                   </div>
@@ -162,54 +190,43 @@ export default async function Home({ params }) {
               })}
             </div>
           </section>
-          <section className="flex flex-col items-start justify-center w-full  md:mt-14 gap-5 text-greendark">
-            <div className="flex flex-col items-start justify-center max-w-[350px] gap-5">
-              <h2 className="font-black text-l-500 md:text-l-600 text-greendark" dangerouslySetInnerHTML={{ __html: dictionary.home.NUESTRO_EMPAQUE }} />
+          <section className="flex w-full flex-col items-start justify-center gap-5 text-greendark md:mt-14">
+            <div className="flex max-w-[350px] flex-col items-start justify-center gap-5">
+              <h2
+                className="font-black text-l-500 text-greendark md:text-l-600"
+                dangerouslySetInnerHTML={{ __html: dictionary.home.NUESTRO_EMPAQUE }}
+              />
             </div>
-            <div className="grid grid-cols-1 md:grid-cols-3 w-full gap-5">
-              <div className="flex items-center justify-center w-full">
-                <Image
-                  src={'/img/mangos_box_ok.webp'}
-                  width={400}
-                  height={200}
-                  alt="mangos en caja"
-                  loading="lazy"
-                  quality={85}
-                />
+            <div className="grid w-full grid-cols-1 gap-5 md:grid-cols-3">
+              <div className="flex w-full items-center justify-center">
+                <Image src={'/img/mangos_box_ok.webp'} width={400} height={200} alt="mangos en caja" loading="lazy" quality={85} />
               </div>
-              <div className="flex flex-col w-full items-center justify-center gap-5">
+              <div className="flex w-full flex-col items-center justify-center gap-5">
                 <p
-                  className="max-w-[350px] text-l-600 text-left md:text-center font-reg leading-10"
+                  className="max-w-[350px] text-left font-reg text-l-600 leading-10 md:text-center"
                   dangerouslySetInnerHTML={{ __html: dictionary.home.GARANTIZAMOS_SEGURIDAD_REQUERIMIENTOS }}
                 />
                 <p
-                  className="max-w-[350px] text-l-300 text-left md:text-center"
+                  className="max-w-[350px] text-left text-l-300 md:text-center"
                   dangerouslySetInnerHTML={{ __html: dictionary.home.UTILIZAMOS_MATERIAL_ALTA_CALIDAD }}
                 />
               </div>
-              <div className="flex items-center justify-center w-full">
-                <Image
-                  src={'/img/pineapples_box_ok.webp'}
-                  width={400}
-                  height={200}
-                  alt="piñas en caja"
-                  loading="lazy"
-                  quality={85}
-                />
+              <div className="flex w-full items-center justify-center">
+                <Image src={'/img/pineapples_box_ok.webp'} width={400} height={200} alt="piñas en caja" loading="lazy" quality={85} />
               </div>
             </div>
           </section>
-          <section className="flex flex-col items-start justify-center w-full md: mt-14 gap-5 text-greendark">
-            <h2 className="font-black text-l-500 md:text-l-600 text-greendark" dangerouslySetInnerHTML={{ __html: dictionary.home.NUESTRA_RUTA }} />
-            <div className="grid grid-cols-1 md:grid-cols-4 w-full gap-10 mt-10">
+          <section className="md: mt-14 flex w-full flex-col items-start justify-center gap-5 text-greendark">
+            <h2 className="font-black text-l-500 text-greendark md:text-l-600" dangerouslySetInnerHTML={{ __html: dictionary.home.NUESTRA_RUTA }} />
+            <div className="mt-10 grid w-full grid-cols-1 gap-10 md:grid-cols-4">
               {RoadFruitMap.map((item, key) => {
                 return (
-                  <div key={key} className="flex w-full flex-col justify-start items-center md:p-5 gap-5">
-                    <div className="flex items-center justify-start w-full gap-3">
+                  <div key={key} className="flex w-full flex-col items-center justify-start gap-5 md:p-5">
+                    <div className="flex w-full items-center justify-start gap-3">
                       <p className="font-black text-l-600">{key + 1}</p>
                       {item.icon}
                     </div>
-                    <div className="flex flex-col items-start justify-start w-full gap-2">
+                    <div className="flex w-full flex-col items-start justify-start gap-2">
                       <p className="font-black text-l-300">{item.title}</p>
                       <p>{item.text}</p>
                     </div>

--- a/apps/web/app/[locale]/page.js
+++ b/apps/web/app/[locale]/page.js
@@ -154,7 +154,8 @@ export default async function Home({ params }) {
                 className="w-full md:w-auto"
                 imageClassName="mb-0 w-full md:mb-28 h-auto md:w-[800px] w-auto"
                 priority
-                quality={90}
+                quality={75}
+                sizes="(max-width: 768px) 90vw, 800px"
               />
             </div>
           </section>

--- a/apps/web/app/[locale]/page.js
+++ b/apps/web/app/[locale]/page.js
@@ -111,7 +111,7 @@ export default async function Home({ params }) {
 
   return (
     <div className="responsiveWidth flex flex-col">
-      <GeneralLayout dictionary={dictionary}>
+      <GeneralLayout dictionary={dictionary} useScrollSmoother>
         <div className="flex w-full flex-col items-center justify-center gap-14">
           <section className="relative mt-10 flex h-full w-full flex-col items-center justify-center gap-7 md:mt-0 md:h-[calc(100vh-180px)]">
             <div className="flex h-full w-full flex-col items-center justify-center md:flex-row">

--- a/apps/web/app/[locale]/products/page.js
+++ b/apps/web/app/[locale]/products/page.js
@@ -121,7 +121,7 @@ const Productos = async ({ params }) => {
     <>
       <ProductSchema locale={locale} />
       <div className="responsiveWidth gap-10">
-        <GeneralLayout dictionary={dictionary}>
+        <GeneralLayout dictionary={dictionary} useScrollSmoother>
           <section className="flex h-full w-full flex-col items-center justify-center gap-7 md:mt-0 md:h-[calc(100vh-180px)]">
             <div className="flex w-full flex-col items-center justify-between md:flex-row">
               <div className="flex w-full flex-col items-start justify-center gap-5 md:w-1/3">

--- a/apps/web/app/layout.js
+++ b/apps/web/app/layout.js
@@ -10,6 +10,37 @@ export const metadata = {
 export default function RootLayout({ children }) {
   return (
     <html lang="es">
+      <head>
+        {/* Preload fuentes críticas para reducir la latencia de la ruta crítica (Lighthouse) */}
+        <link
+          rel="preload"
+          href="/fonts/pop_regular.ttf"
+          as="font"
+          type="font/ttf"
+          crossOrigin="anonymous"
+        />
+        <link
+          rel="preload"
+          href="/fonts/pop_medium.ttf"
+          as="font"
+          type="font/ttf"
+          crossOrigin="anonymous"
+        />
+        <link
+          rel="preload"
+          href="/fonts/pop_black.ttf"
+          as="font"
+          type="font/ttf"
+          crossOrigin="anonymous"
+        />
+        <link
+          rel="preload"
+          href="/fonts/yesteryear.ttf"
+          as="font"
+          type="font/ttf"
+          crossOrigin="anonymous"
+        />
+      </head>
       <body className="bg-fresh">{children}</body>
     </html>
   );

--- a/apps/web/components/blog-hero/blog-hero.js
+++ b/apps/web/components/blog-hero/blog-hero.js
@@ -6,7 +6,7 @@ import { ScrollTrigger } from 'gsap/ScrollTrigger';
 
 gsap.registerPlugin(ScrollTrigger);
 
-const BlogHero = ({ children, image, brightness, yOffset }) => {
+const BlogHero = ({ children, image, brightness, yOffset, isCover = true }) => {
   const containerRef = useRef(null);
   const bgRef = useRef(null);
 
@@ -45,7 +45,7 @@ const BlogHero = ({ children, image, brightness, yOffset }) => {
     <div ref={containerRef} className="relative flex h-full w-full flex-col items-start justify-center overflow-hidden rounded-3xl">
       <div
         ref={bgRef}
-        className="absolute left-0 w-full bg-cover bg-center bg-no-repeat"
+        className={`absolute left-0 w-full bg-center bg-no-repeat ${isCover ? 'bg-cover' : 'bg-contain'}`}
         style={{
           backgroundImage: `url(${image})`,
           filter: brightness ? `brightness(${brightness})` : 'brightness(0.6)',

--- a/apps/web/components/blog-hero/blog-hero.js
+++ b/apps/web/components/blog-hero/blog-hero.js
@@ -45,7 +45,7 @@ const BlogHero = ({ children, image, brightness, yOffset, isCover = true }) => {
     <div ref={containerRef} className="relative flex h-full w-full flex-col items-start justify-center overflow-hidden rounded-3xl">
       <div
         ref={bgRef}
-        className={`absolute left-0 w-full bg-center bg-no-repeat ${isCover ? 'bg-cover' : 'bg-contain'}`}
+        className={`absolute left-0 w-full bg-center bg-no-repeat ${isCover ? 'bg-cover' : 'bg-[length:auto_100%] md:bg-contain'}`}
         style={{
           backgroundImage: `url(${image})`,
           filter: brightness ? `brightness(${brightness})` : 'brightness(0.6)',

--- a/apps/web/components/language-switcher/language-switcher.js
+++ b/apps/web/components/language-switcher/language-switcher.js
@@ -5,7 +5,7 @@ import { usePathname, useRouter } from 'next/navigation';
 import { useEffect, useRef, useState, useTransition } from 'react';
 import { MdLanguage } from 'react-icons/md';
 
-const LanguageSwitcher = () => {
+const LanguageSwitcher = ({ alternateUrls = null }) => {
   const router = useRouter();
   const pathname = usePathname();
   const [currentLocale, setCurrentLocale] = useState('es');
@@ -42,8 +42,11 @@ const LanguageSwitcher = () => {
 
   const toggleLocale = () => {
     const newLocale = currentLocale === 'es' ? 'en' : 'es';
-    const pathWithoutLocale = pathname.replace(/^\/(es|en)/, '') || '/';
-    const newPath = `/${newLocale}${pathWithoutLocale === '/' ? '' : pathWithoutLocale}`;
+    // Si hay URLs alternativas (ej. post con slugs distintos por idioma), usar la correcta
+    const newPath = alternateUrls?.[newLocale] ?? (() => {
+      const pathWithoutLocale = pathname.replace(/^\/(es|en)/, '') || '/';
+      return `/${newLocale}${pathWithoutLocale === '/' ? '' : pathWithoutLocale}`;
+    })();
 
     // Guardar la posición actual del scroll en sessionStorage antes de navegar
     const scrollPosition = window.scrollY || window.pageYOffset;

--- a/apps/web/components/language-switcher/language-switcher.js
+++ b/apps/web/components/language-switcher/language-switcher.js
@@ -2,7 +2,7 @@
 
 import classNames from 'classnames';
 import { usePathname, useRouter } from 'next/navigation';
-import { useEffect, useState, useTransition } from 'react';
+import { useEffect, useRef, useState, useTransition } from 'react';
 import { MdLanguage } from 'react-icons/md';
 
 const LanguageSwitcher = () => {
@@ -11,11 +11,17 @@ const LanguageSwitcher = () => {
   const [currentLocale, setCurrentLocale] = useState('es');
   const [isHover, setIsHover] = useState(false);
   const [isPending, startTransition] = useTransition();
+  const prevLocaleRef = useRef(null);
 
   useEffect(() => {
     const localeFromPath = pathname.split('/')[1];
     if (localeFromPath && (localeFromPath === 'es' || localeFromPath === 'en')) {
       setCurrentLocale(localeFromPath);
+      // Solo refrescar cuando el locale cambió (ej. al cambiar idioma en el blog)
+      if (prevLocaleRef.current !== null && prevLocaleRef.current !== localeFromPath) {
+        router.refresh();
+      }
+      prevLocaleRef.current = localeFromPath;
     }
 
     // Restaurar la posición del scroll si se cambió el idioma

--- a/apps/web/components/post-card/post-card.js
+++ b/apps/web/components/post-card/post-card.js
@@ -1,5 +1,6 @@
 import { ParallaxContainer } from '@/components/parallax';
 import { urlFor } from '@/sanity/lib/image';
+import { ScrollReveal } from '@/components/scroll-reveal';
 
 const { default: Image } = require('next/image');
 const { default: Link } = require('next/link');
@@ -20,31 +21,35 @@ const PostCard = ({ post, featured = false, locale }) => (
     >
       <div className="flex h-full grow flex-col justify-between p-10">
         <div className="mb-20 flex flex-wrap gap-2">
-          {post?.categories?.map((category, index) => (
-            <div key={index} className="flex items-center justify-center rounded-full border border-white px-2 py-1">
-              <p key={index} className="rounded-full px-2 py-1 text-xs text-white">
-                {category}
-              </p>
-            </div>
-          ))}
+          <p className="rounded-full px-2 py-1 text-xs text-white">
+            <ScrollReveal start="bottom 90%" from={{ opacity: 0, y: 30 }} duration={1.3} delay={0.2} once={false}>
+              {post?.categories?.map((category, index) => (
+                <div key={index} className="flex items-center justify-center rounded-full border border-white px-2 py-1">
+                  <p key={index} className="rounded-full px-2 py-1 text-xs text-white">
+                    {category}
+                  </p>
+                </div>
+              ))}
+            </ScrollReveal>
+          </p>
         </div>
 
-        <p className={`mb-2 line-clamp-2 font-black text-l-300 text-white`}>{post.title}</p>
-
-        {post.excerpt && <p className="font-regular mb-4 line-clamp-2 text-l-100 text-white">{post.excerpt}</p>}
-
-        <div className="flex items-center justify-between text-sm text-white">
-          {post.author && <span>{post.author}</span>}
-          {post.publishedAt && (
-            <time dateTime={post.publishedAt}>
-              {new Date(post.publishedAt).toLocaleDateString(locale, {
-                year: 'numeric',
-                month: 'long',
-                day: 'numeric',
-              })}
-            </time>
-          )}
-        </div>
+        <ScrollReveal start="top 80%" from={{ opacity: 0, y: 30 }} duration={1.3} delay={0.2} once={false}>
+          <p className={`mb-2 line-clamp-2 font-black text-l-300 text-white`}>{post.title}</p>
+        </ScrollReveal>
+        <ScrollReveal start="top 80%" from={{ opacity: 0, y: 40 }} duration={1.3} delay={0.3} once={false}>
+          {post.excerpt && <p className="font-regular mb-4 line-clamp-2 text-l-100 text-white">{post.excerpt}</p>}
+        </ScrollReveal>
+        <ScrollReveal start="top 80%" from={{ opacity: 0, y: 50 }} duration={1.3} delay={0.5} once={false}>
+          <div className="flex items-center justify-between text-sm text-white">
+            {post.author && <span>{post.author}</span>}
+            {post.publishedAt && (
+              <time dateTime={post.publishedAt}>
+                {new Date(post.publishedAt).toLocaleDateString(locale, { year: 'numeric', month: 'long', day: 'numeric' })}
+              </time>
+            )}
+          </div>
+        </ScrollReveal>
       </div>
     </ParallaxContainer>
   </Link>

--- a/apps/web/middleware.js
+++ b/apps/web/middleware.js
@@ -70,6 +70,11 @@ function detectLanguageByCountry(countryCode) {
 export function middleware(request) {
   const { pathname } = request.nextUrl;
 
+  // No redirigir /404 - tiene su propia página para evitar errores de prerender
+  if (pathname === '/404') {
+    return NextResponse.next();
+  }
+
   const isMissingLocale = i18n.locales.every(locale => !pathname.startsWith(`/${locale}`));
 
   if (isMissingLocale) {

--- a/apps/web/middleware.js
+++ b/apps/web/middleware.js
@@ -67,6 +67,12 @@ function detectLanguageByCountry(countryCode) {
   return null;
 }
 
+/** /[locale]/blog/[slug] — el slug puede ser solo válido en un idioma; no forzar cookie sobre la URL */
+function isBlogArticlePath(pathname) {
+  const parts = pathname.split('/').filter(Boolean);
+  return parts.length === 3 && parts[1] === 'blog' && i18n.locales.includes(parts[0]);
+}
+
 export function middleware(request) {
   const { pathname } = request.nextUrl;
 
@@ -118,9 +124,14 @@ export function middleware(request) {
     const response = NextResponse.next();
     const cookieLocale = request.cookies.get('NEXT_LOCALE')?.value;
 
-    // CRÍTICO: Si el locale en la URL no coincide con la cookie, redirigir a la cookie
-    // Esto asegura que la preferencia del usuario siempre se respete
-    if (cookieLocale && cookieLocale !== currentLocale && i18n.locales.includes(cookieLocale)) {
+    // Si el locale en la URL no coincide con la cookie, redirigir a la cookie — excepto en
+    // artículos del blog, donde el slug es por idioma y no debe mezclarse con otro locale.
+    if (
+      cookieLocale &&
+      cookieLocale !== currentLocale &&
+      i18n.locales.includes(cookieLocale) &&
+      !isBlogArticlePath(pathname)
+    ) {
       const newPath = pathname.replace(`/${currentLocale}`, `/${cookieLocale}`);
       const redirectResponse = NextResponse.redirect(new URL(newPath, request.url));
       // Reforzar la cookie

--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -1,6 +1,15 @@
 export default {
   reactStrictMode: true,
   compress: true,
+  webpack: (config) => {
+    config.resolve.alias = {
+      ...config.resolve.alias,
+      // Evita polyfills innecesarios en navegadores modernos (Lighthouse: Legacy JavaScript)
+      '../build/polyfills/polyfill-module': false,
+      'next/dist/build/polyfills/polyfill-module': false,
+    };
+    return config;
+  },
   images: {
     formats: ['image/avif', 'image/webp'],
     deviceSizes: [640, 750, 828, 1080, 1200, 1920, 2048, 3840],

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -34,6 +34,12 @@
     "styled-components": "^6.3.10",
     "tailwindcss": "^3.4.17"
   },
+  "browserslist": [
+    "chrome 111",
+    "edge 111",
+    "firefox 111",
+    "safari 16.4"
+  ],
   "devDependencies": {
     "eslint": "^8.57.0",
     "eslint-config-next": "^15.2.4",

--- a/apps/web/src/components/footer/footer.js
+++ b/apps/web/src/components/footer/footer.js
@@ -25,27 +25,27 @@ const Footer = ({ dictionary }) => {
   const redSocItems = [
     {
       red: 'instagram',
-      icon: <FaInstagram size={20} color="#224C22" />,
+      icon: <FaInstagram size={20} color="#224C22" className="transition-all duration-100 hover:scale-125" />,
       url: '',
     },
     {
       red: 'twitter',
-      icon: <RiTwitterXLine size={20} color="#224C22" />,
+      icon: <RiTwitterXLine size={20} color="#224C22" className="transition-all duration-100 hover:scale-125" />,
       url: '',
     },
     {
       red: 'linkedin',
-      icon: <FaLinkedinIn size={20} color="#224C22" />,
+      icon: <FaLinkedinIn size={20} color="#224C22" className="transition-all duration-100 hover:scale-125" />,
       url: '',
     },
     {
       red: 'google',
-      icon: <FaGoogle size={20} color="#224C22" />,
+      icon: <FaGoogle size={20} color="#224C22" className="transition-all duration-100 hover:scale-125" />,
       url: '',
     },
     {
       red: 'tridge',
-      icon: <TridgeLogo width={20} height={20} color="#224C22" />,
+      icon: <TridgeLogo width={20} height={20} color="#224C22" className="transition-all duration-100 hover:scale-125" />,
       url: 'https://www.tridge.com/seller/premium-profile-preview/BOH-c033c708',
     },
   ];
@@ -75,14 +75,10 @@ const Footer = ({ dictionary }) => {
           <div className="mb-3 mt-3 grid grid-cols-5 gap-2">
             {redSocItems.map((item, key) => {
               return (
-                <div key={key} className="flex h-auto w-[40px] items-center justify-center">
-                  {item.url ? (
-                    <a href={item.url} target="_blank" rel="noopener noreferrer" className="transition-opacity hover:opacity-70">
-                      {item.icon}
-                    </a>
-                  ) : (
-                    <button>{item.icon}</button>
-                  )}
+                <div key={key} className="flex h-[40px] w-[40px] items-center justify-center transition-all">
+                  <a href={item.url} target="_blank" rel="noopener noreferrer">
+                    {item.icon}
+                  </a>
                 </div>
               );
             })}
@@ -96,14 +92,14 @@ const Footer = ({ dictionary }) => {
             <div className="flex items-center justify-center gap-2">
               <Link
                 href={`/${locale}/certificates`}
-                className="transition-opacity hover:opacity-70 cursor-pointer flex items-center"
+                className="flex cursor-pointer items-center transition-opacity hover:opacity-70"
                 aria-label="Ver certificaciones Global GAP"
               >
                 <GlobalGapIcon width={50} height={40} color="#224C22" />
               </Link>
               <Link
                 href={`/${locale}/certificates`}
-                className="transition-opacity hover:opacity-70 cursor-pointer flex items-center"
+                className="flex cursor-pointer items-center transition-opacity hover:opacity-70"
                 aria-label="Ver certificaciones NSF"
               >
                 <NsfIcon width={40} height={40} color="#224C22" />

--- a/apps/web/src/components/general-layout/general-layout.js
+++ b/apps/web/src/components/general-layout/general-layout.js
@@ -13,7 +13,7 @@ const GeneralLayout = ({ children, dictionary, showFooter = true, overflowHidden
 
   return (
     <div
-      className={`flex w-full flex-col items-center justify-between ${overflowHidden && !useScrollSmoother ? 'overflow-hidden' : ''} h-auto`}
+      className={`mb-20 flex w-full flex-col items-center justify-between ${overflowHidden && !useScrollSmoother ? 'overflow-hidden' : ''} h-auto`}
     >
       <Header dictionary={dictionary} alternateUrls={alternateUrls} />
       {useScrollSmoother ? <ScrollSmootherProvider>{content}</ScrollSmootherProvider> : content}

--- a/apps/web/src/components/general-layout/general-layout.js
+++ b/apps/web/src/components/general-layout/general-layout.js
@@ -1,23 +1,22 @@
-import React from "react";
-import Header from "../header/header";
-import Footer from "../footer/footer";
+import React from 'react';
+import Header from '../header/header';
+import Footer from '../footer/footer';
+import ScrollSmootherProvider from '../scroll-smoother';
 
-const GeneralLayout = ({
-  children,
-  dictionary,
-  showFooter = true,
-  overflowHidden = false,
-  alternateUrls = null,
-}) => {
+const GeneralLayout = ({ children, dictionary, showFooter = true, overflowHidden = false, alternateUrls = null, useScrollSmoother = false }) => {
+  const content = (
+    <>
+      <div className={`mb-10 flex w-full flex-col md:mt-[130px] ${overflowHidden ? 'overflow-hidden' : ''}`}>{children}</div>
+      {showFooter && <Footer dictionary={dictionary} />}
+    </>
+  );
+
   return (
     <div
-      className={`flex flex-col items-center justify-between ${
-        overflowHidden && "overflow-hidden"
-      } h-auto`}
+      className={`flex w-full flex-col items-center justify-between ${overflowHidden && !useScrollSmoother ? 'overflow-hidden' : ''} h-auto`}
     >
       <Header dictionary={dictionary} alternateUrls={alternateUrls} />
-      <div className="md:mt-[130px] flex flex-col w-full mb-10">{children}</div>
-      {showFooter && <Footer dictionary={dictionary} />}
+      {useScrollSmoother ? <ScrollSmootherProvider>{content}</ScrollSmootherProvider> : content}
     </div>
   );
 };

--- a/apps/web/src/components/general-layout/general-layout.js
+++ b/apps/web/src/components/general-layout/general-layout.js
@@ -7,6 +7,7 @@ const GeneralLayout = ({
   dictionary,
   showFooter = true,
   overflowHidden = false,
+  alternateUrls = null,
 }) => {
   return (
     <div
@@ -14,7 +15,7 @@ const GeneralLayout = ({
         overflowHidden && "overflow-hidden"
       } h-auto`}
     >
-      <Header dictionary={dictionary} />
+      <Header dictionary={dictionary} alternateUrls={alternateUrls} />
       <div className="md:mt-[130px] flex flex-col w-full mb-10">{children}</div>
       {showFooter && <Footer dictionary={dictionary} />}
     </div>

--- a/apps/web/src/components/header/header.js
+++ b/apps/web/src/components/header/header.js
@@ -7,7 +7,7 @@ import Menu from '../menu/menu';
 import LanguageSwitcher from 'components/language-switcher/language-switcher';
 import BurgerMenu from '../burger-menu/burger-menu';
 
-const Header = ({ dictionary }) => {
+const Header = ({ dictionary, alternateUrls = null }) => {
   const pathname = usePathname();
   const [isAtTop, setIsAtTop] = useState(true);
 
@@ -36,7 +36,7 @@ const Header = ({ dictionary }) => {
           <Image src={'/img/freshfood_logo.svg'} height={50} width={300} alt="freshfood logo" />
         </div>
         <div className="flex w-1/5 items-center justify-center">
-          <LanguageSwitcher />
+          <LanguageSwitcher alternateUrls={alternateUrls} />
         </div>
       </div>
       <div className="hidden flex-1 md:flex">
@@ -48,7 +48,7 @@ const Header = ({ dictionary }) => {
       </Link>
 
       <div className="hidden flex-1 items-center justify-end gap-5 md:flex">
-        <LanguageSwitcher />
+        <LanguageSwitcher alternateUrls={alternateUrls} />
         <Link
           href={`/${pathname.split('/')[1] || 'es'}/contact`}
           className="flex items-center justify-center rounded-full border-2 border-greendark px-4 py-2 text-l-100 transition-all hover:bg-greendark hover:text-white md:hover:px-8"

--- a/apps/web/src/components/parallax/ParallaxImage.js
+++ b/apps/web/src/components/parallax/ParallaxImage.js
@@ -15,12 +15,15 @@ gsap.registerPlugin(ScrollTrigger);
  * @param {number} speed - Velocidad del parallax (menor = más lento). Default: 0.5
  * @param {string} className - Clases adicionales para el contenedor
  * @param {string} imageClassName - Clases adicionales para la imagen
+ * @param {string} imageWrapperClassName - Clases para el wrapper de la imagen (fill=false)
  * @param {boolean} fill - Si la imagen debe llenar el contenedor. Default: true
  * @param {number} width - Ancho de la imagen (si fill=false)
  * @param {number} height - Alto de la imagen (si fill=false)
  * @param {string} objectFit - Ajuste de la imagen. Default: 'cover'
  * @param {number} scale - Escala para parallax. 1.3 para fill, 1.05 sutil para dimensiones fijas
  * @param {number} quality - Calidad de la imagen (Next.js)
+ * @param {boolean} fadeIn - Aplica fade-in al cargar. Default: false
+ * @param {boolean} zoomIn - Aplica zoom-in al cargar. Default: false
  */
 const ParallaxImage = ({
   src,
@@ -28,6 +31,9 @@ const ParallaxImage = ({
   speed = 0.5,
   className = '',
   imageClassName = '',
+  imageWrapperClassName = '',
+  fadeIn = false,
+  zoomIn = false,
   fill = true,
   width,
   height,
@@ -39,23 +45,39 @@ const ParallaxImage = ({
   // Scale sutil cuando hay dimensiones fijas para no alterar el aspecto
   const parallaxScale = scale ?? (fill ? 1.3 : 1.05);
   const containerRef = useRef(null);
-  const imageRef = useRef(null);
+  const parallaxRef = useRef(null);
+  const innerRef = useRef(null);
 
   useEffect(() => {
     const container = containerRef.current;
-    const image = imageRef.current;
+    const parallax = parallaxRef.current;
+    const inner = innerRef.current;
 
-    if (!container || !image) return;
+    if (!container || !parallax) return;
+    if ((fadeIn || zoomIn) && !inner) return;
 
     const movement = (1 - speed) * 50;
+    const target = inner;
 
     const ctx = gsap.context(() => {
-      gsap.set(image, {
+      gsap.set(parallax, {
         scale: parallaxScale,
         yPercent: -movement / 2,
       });
 
-      gsap.to(image, {
+      if (fadeIn || zoomIn) {
+        const vars = {};
+        if (fadeIn) vars.opacity = 1;
+        if (zoomIn) vars.scale = 1;
+        gsap.to(target, {
+          ...vars,
+          duration: 1,
+          ease: 'power2.out',
+          overwrite: true,
+        });
+      }
+
+      gsap.to(parallax, {
         yPercent: movement / 2,
         ease: 'none',
         scrollTrigger: {
@@ -68,22 +90,43 @@ const ParallaxImage = ({
     });
 
     return () => ctx.revert();
-  }, [speed, parallaxScale]);
+  }, [speed, parallaxScale, fadeIn, zoomIn]);
 
   const containerClass = fill
     ? `relative h-full w-full min-h-[100px] self-stretch overflow-hidden ${className}`.trim()
     : `relative inline-block overflow-hidden ${className}`.trim();
 
-  const imageWrapperClass = fill ? 'absolute inset-0' : 'relative';
+  const parallaxClass = fill ? 'absolute inset-0' : `relative ${imageWrapperClassName}`.trim();
+
+  const innerClass = fill
+    ? `absolute inset-0 ${fadeIn ? 'opacity-0' : ''} ${zoomIn ? 'scale-0' : ''}`.trim()
+    : `block ${fadeIn ? 'opacity-0' : ''} ${zoomIn ? 'scale-0' : ''}`.trim();
 
   return (
     <div ref={containerRef} className={containerClass}>
-      <div ref={imageRef} className={imageWrapperClass}>
-        {fill ? (
-          <Image src={src} alt={alt} fill className={`object-${objectFit} ${imageClassName}`} priority={priority} sizes="(max-width: 768px) 100vw, 800px" />
-        ) : (
-          <Image src={src} alt={alt} width={width} height={height} className={`object-${objectFit} ${imageClassName}`} priority={priority} quality={quality} />
-        )}
+      <div ref={parallaxRef} className={parallaxClass}>
+        <div ref={innerRef} className={innerClass}>
+          {fill ? (
+            <Image
+              src={src}
+              alt={alt}
+              fill
+              className={`object-${objectFit} ${imageClassName}`}
+              priority={priority}
+              sizes="(max-width: 768px) 100vw, 800px"
+            />
+          ) : (
+            <Image
+              src={src}
+              alt={alt}
+              width={width}
+              height={height}
+              className={`object-${objectFit} ${imageClassName}`}
+              priority={priority}
+              quality={quality}
+            />
+          )}
+        </div>
       </div>
     </div>
   );

--- a/apps/web/src/components/parallax/ParallaxImage.js
+++ b/apps/web/src/components/parallax/ParallaxImage.js
@@ -19,7 +19,8 @@ gsap.registerPlugin(ScrollTrigger);
  * @param {number} width - Ancho de la imagen (si fill=false)
  * @param {number} height - Alto de la imagen (si fill=false)
  * @param {string} objectFit - Ajuste de la imagen. Default: 'cover'
- * @param {number} scale - Escala adicional para evitar espacios vacíos. Default: 1.3
+ * @param {number} scale - Escala para parallax. 1.3 para fill, 1.05 sutil para dimensiones fijas
+ * @param {number} quality - Calidad de la imagen (Next.js)
  */
 const ParallaxImage = ({
   src,
@@ -31,9 +32,12 @@ const ParallaxImage = ({
   width,
   height,
   objectFit = 'cover',
-  scale = 1.3,
+  scale,
   priority = false,
+  quality,
 }) => {
+  // Scale sutil cuando hay dimensiones fijas para no alterar el aspecto
+  const parallaxScale = scale ?? (fill ? 1.3 : 1.05);
   const containerRef = useRef(null);
   const imageRef = useRef(null);
 
@@ -47,7 +51,7 @@ const ParallaxImage = ({
 
     const ctx = gsap.context(() => {
       gsap.set(image, {
-        scale: scale,
+        scale: parallaxScale,
         yPercent: -movement / 2,
       });
 
@@ -64,15 +68,21 @@ const ParallaxImage = ({
     });
 
     return () => ctx.revert();
-  }, [speed, scale]);
+  }, [speed, parallaxScale]);
+
+  const containerClass = fill
+    ? `relative h-full w-full min-h-[100px] self-stretch overflow-hidden ${className}`.trim()
+    : `relative inline-block overflow-hidden ${className}`.trim();
+
+  const imageWrapperClass = fill ? 'absolute inset-0' : 'relative';
 
   return (
-    <div ref={containerRef} className={`relative overflow-hidden ${className}`}>
-      <div ref={imageRef} className="h-full w-full">
+    <div ref={containerRef} className={containerClass}>
+      <div ref={imageRef} className={imageWrapperClass}>
         {fill ? (
-          <Image src={src} alt={alt} fill className={`object-${objectFit} ${imageClassName}`} priority={priority} />
+          <Image src={src} alt={alt} fill className={`object-${objectFit} ${imageClassName}`} priority={priority} sizes="(max-width: 768px) 100vw, 800px" />
         ) : (
-          <Image src={src} alt={alt} width={width} height={height} className={`object-${objectFit} ${imageClassName}`} priority={priority} />
+          <Image src={src} alt={alt} width={width} height={height} className={`object-${objectFit} ${imageClassName}`} priority={priority} quality={quality} />
         )}
       </div>
     </div>

--- a/apps/web/src/components/parallax/ParallaxImage.js
+++ b/apps/web/src/components/parallax/ParallaxImage.js
@@ -22,6 +22,7 @@ gsap.registerPlugin(ScrollTrigger);
  * @param {string} objectFit - Ajuste de la imagen. Default: 'cover'
  * @param {number} scale - Escala para parallax. 1.3 para fill, 1.05 sutil para dimensiones fijas
  * @param {number} quality - Calidad de la imagen (Next.js)
+ * @param {string} sizes - Atributo sizes para responsive (Next.js Image). Recomendado cuando fill=false
  * @param {boolean} fadeIn - Aplica fade-in al cargar. Default: false
  * @param {boolean} zoomIn - Aplica zoom-in al cargar. Default: false
  */
@@ -41,6 +42,7 @@ const ParallaxImage = ({
   scale,
   priority = false,
   quality,
+  sizes,
 }) => {
   // Scale sutil cuando hay dimensiones fijas para no alterar el aspecto
   const parallaxScale = scale ?? (fill ? 1.3 : 1.05);
@@ -124,6 +126,7 @@ const ParallaxImage = ({
               className={`object-${objectFit} ${imageClassName}`}
               priority={priority}
               quality={quality}
+              sizes={sizes}
             />
           )}
         </div>

--- a/apps/web/src/components/scroll-reveal/ScrollReveal.js
+++ b/apps/web/src/components/scroll-reveal/ScrollReveal.js
@@ -1,0 +1,84 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+import { gsap } from 'gsap';
+import { ScrollTrigger } from 'gsap/ScrollTrigger';
+
+gsap.registerPlugin(ScrollTrigger);
+
+/**
+ * Componente reutilizable que anima children con GSAP .from cuando entra en viewport
+ *
+ * @param {React.ReactNode} children - Contenido a animar
+ * @param {string} start - Posición de inicio del ScrollTrigger. Default: 'top 85%' (dispara cuando el top del elemento llega al 85% del viewport)
+ * @param {Object} from - Propiedades iniciales de gsap.from (antes de la animación). Default: { opacity: 0, y: 40 }
+ * @param {Object} to - Propiedades finales (opcional, para fromTo). Si no se pasa, usa valores por defecto
+ * @param {number} duration - Duración de la animación en segundos. Default: 0.8
+ * @param {number} delay - Retraso antes de la animación. Default: 0
+ * @param {string} ease - Ease de la animación. Default: 'power3.out'
+ * @param {string} className - Clases adicionales para el wrapper
+ * @param {Object} style - Estilos inline para el wrapper
+ * @param {boolean} once - Si true, la animación solo se ejecuta una vez. Default: true
+ */
+const ScrollReveal = ({
+  children,
+  start = 'top 85%',
+  from = { opacity: 0, y: 40 },
+  to,
+  duration = 0.8,
+  delay = 0,
+  ease = 'power3.out',
+  className = '',
+  style = {},
+  once = true,
+}) => {
+  const ref = useRef(null);
+
+  // Estilo inicial para evitar flash: el elemento empieza oculto desde el primer paint
+  const initialStyle = {
+    opacity: from?.opacity ?? 0,
+    transform: `translate(${from?.x ?? 0}px, ${from?.y ?? 40}px)${from?.scale !== undefined ? ` scale(${from.scale})` : ''}`,
+    ...style,
+  };
+
+  useEffect(() => {
+    const element = ref.current;
+    if (!element) return;
+
+    // fromTo con estado final explícito: evita que gsap lea el inline style como destino
+    const toState = to ?? {
+      opacity: 1,
+      x: 0,
+      y: 0,
+      ...(from?.scale !== undefined && { scale: 1 }),
+    };
+
+    const ctx = gsap.context(() => {
+      const animation = gsap.fromTo(element, from, {
+        ...toState,
+        duration,
+        delay,
+        ease,
+        paused: true,
+      });
+
+      ScrollTrigger.create({
+        trigger: element,
+        start,
+        animation,
+        toggleActions: once ? 'play none none none' : 'play none none reverse',
+        markers: true,
+      });
+    });
+
+    return () => ctx.revert();
+  }, [start, from, to, duration, delay, ease, once]);
+
+  return (
+    <div ref={ref} className={className} style={initialStyle}>
+      {children}
+    </div>
+  );
+};
+
+export default ScrollReveal;

--- a/apps/web/src/components/scroll-reveal/ScrollReveal.js
+++ b/apps/web/src/components/scroll-reveal/ScrollReveal.js
@@ -20,7 +20,7 @@ gsap.registerPlugin(ScrollTrigger);
  * @param {Object} style - Estilos inline para el wrapper
  * @param {boolean} once - Si true, la animación solo se ejecuta una vez. Default: true
  */
-const ScrollReveal = ({
+export const ScrollReveal = ({
   children,
   start = 'top 85%',
   from = { opacity: 0, y: 40 },
@@ -80,5 +80,3 @@ const ScrollReveal = ({
     </div>
   );
 };
-
-export default ScrollReveal;

--- a/apps/web/src/components/scroll-reveal/ScrollReveal.js
+++ b/apps/web/src/components/scroll-reveal/ScrollReveal.js
@@ -67,7 +67,7 @@ const ScrollReveal = ({
         start,
         animation,
         toggleActions: once ? 'play none none none' : 'play none none reverse',
-        markers: true,
+        // markers: true,
       });
     });
 

--- a/apps/web/src/components/scroll-reveal/index.js
+++ b/apps/web/src/components/scroll-reveal/index.js
@@ -1,0 +1,1 @@
+export { default } from './ScrollReveal';

--- a/apps/web/src/components/scroll-reveal/index.js
+++ b/apps/web/src/components/scroll-reveal/index.js
@@ -1,1 +1,1 @@
-export { default } from './ScrollReveal';
+export { ScrollReveal } from './ScrollReveal';

--- a/apps/web/src/components/scroll-smoother/ScrollSmootherProvider.js
+++ b/apps/web/src/components/scroll-smoother/ScrollSmootherProvider.js
@@ -39,7 +39,7 @@ const ScrollSmootherProvider = ({ children }) => {
 
   return (
     <div ref={wrapperRef} id="smooth-wrapper" className="fixed inset-0 z-0 overflow-hidden">
-      <div ref={contentRef} id="smooth-content" className="responsiveWidth flex w-full flex-col items-center">
+      <div ref={contentRef} id="smooth-content" className="responsiveWidth flex w-full flex-col items-center px-[5%] pb-20 md:px-0">
         {children}
       </div>
     </div>

--- a/apps/web/src/components/scroll-smoother/ScrollSmootherProvider.js
+++ b/apps/web/src/components/scroll-smoother/ScrollSmootherProvider.js
@@ -1,0 +1,49 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+import { gsap } from 'gsap';
+import { ScrollTrigger } from 'gsap/ScrollTrigger';
+import { ScrollSmoother } from 'gsap/ScrollSmoother';
+
+gsap.registerPlugin(ScrollTrigger, ScrollSmoother);
+
+/**
+ * Envuelve el contenido en la estructura requerida por ScrollSmoother
+ * y crea la instancia. Solo para la vista home.
+ *
+ * Requiere: smooth-wrapper > smooth-content > children
+ * El Header debe estar FUERA de este componente (position: fixed).
+ */
+const ScrollSmootherProvider = ({ children }) => {
+  const wrapperRef = useRef(null);
+  const contentRef = useRef(null);
+
+  useEffect(() => {
+    const wrapper = wrapperRef.current;
+    const content = contentRef.current;
+
+    if (!wrapper || !content) return;
+
+    const smoother = ScrollSmoother.create({
+      wrapper: wrapper,
+      content: content,
+      smooth: 1,
+      effects: true,
+      smoothTouch: 0.1,
+    });
+
+    return () => {
+      smoother.kill();
+    };
+  }, []);
+
+  return (
+    <div ref={wrapperRef} id="smooth-wrapper" className="fixed inset-0 z-0 overflow-hidden">
+      <div ref={contentRef} id="smooth-content" className="responsiveWidth flex w-full flex-col items-center">
+        {children}
+      </div>
+    </div>
+  );
+};
+
+export default ScrollSmootherProvider;

--- a/apps/web/src/components/scroll-smoother/index.js
+++ b/apps/web/src/components/scroll-smoother/index.js
@@ -1,0 +1,1 @@
+export { default } from './ScrollSmootherProvider';

--- a/apps/web/src/components/text-animate/index.js
+++ b/apps/web/src/components/text-animate/index.js
@@ -1,0 +1,1 @@
+export { TextAnimate } from './text-animate';

--- a/apps/web/src/components/text-animate/text-animate.js
+++ b/apps/web/src/components/text-animate/text-animate.js
@@ -1,0 +1,65 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+import { gsap } from 'gsap';
+
+/**
+ * Componente que anima texto al montar (sin ScrollTrigger).
+ * Ideal para contenido en el hero/top que debe aparecer al cargar la página.
+ *
+ * @param {React.ReactNode} children - Contenido a animar
+ * @param {Object} from - Propiedades iniciales. Default: { opacity: 0, y: 40 }
+ * @param {Object} to - Propiedades finales (opcional)
+ * @param {number} duration - Duración en segundos. Default: 0.8
+ * @param {number} delay - Retraso antes de la animación. Default: 0
+ * @param {string} ease - Ease. Default: 'power3.out'
+ * @param {string} className - Clases adicionales
+ * @param {Object} style - Estilos inline
+ */
+export const TextAnimate = ({
+  children,
+  from = { opacity: 0, y: 40 },
+  to,
+  duration = 0.8,
+  delay = 0,
+  ease = 'power3.out',
+  className = '',
+  style = {},
+}) => {
+  const ref = useRef(null);
+
+  const initialStyle = {
+    opacity: from?.opacity ?? 0,
+    transform: `translate(${from?.x ?? 0}px, ${from?.y ?? 40}px)${from?.scale !== undefined ? ` scale(${from.scale})` : ''}`,
+    ...style,
+  };
+
+  useEffect(() => {
+    const element = ref.current;
+    if (!element) return;
+
+    const toState = to ?? {
+      opacity: 1,
+      x: 0,
+      y: 0,
+      ...(from?.scale !== undefined && { scale: 1 }),
+    };
+
+    const ctx = gsap.context(() => {
+      gsap.fromTo(element, from, {
+        ...toState,
+        duration,
+        delay,
+        ease,
+      });
+    });
+
+    return () => ctx.revert();
+  }, [from, to, duration, delay, ease]);
+
+  return (
+    <div ref={ref} className={`relative ${className}`.trim()} style={initialStyle}>
+      {children}
+    </div>
+  );
+};

--- a/apps/web/src/lib/resolveBlogPost.js
+++ b/apps/web/src/lib/resolveBlogPost.js
@@ -1,0 +1,34 @@
+import { redirect } from 'next/navigation';
+import { safeFetch, checkSanityConfig } from '@/sanity/lib/client';
+import { postBySlugQuery, postBySlugAnyLanguageQuery } from '@/sanity/lib/queries';
+
+async function fetchPost(slug, language) {
+  return await safeFetch(postBySlugQuery, { slug, language });
+}
+
+/**
+ * Obtiene el post por slug + idioma. Si la URL mezcla locale y slug de otro idioma,
+ * redirige a la URL canónica (traducción en el idioma pedido o versión original).
+ */
+export async function resolveBlogPost(slug, locale) {
+  const post = await fetchPost(slug, locale);
+  if (post) return post;
+
+  if (!checkSanityConfig()) return null;
+
+  const hint = await safeFetch(postBySlugAnyLanguageQuery, { slug });
+  if (!hint) return null;
+
+  if (hint.language === locale) {
+    const retry = await fetchPost(hint.slug, locale);
+    return retry ?? null;
+  }
+
+  const translations = (hint._translations || []).filter(t => t?.slug && t?.language);
+  const forLocale = translations.find(t => t.language === locale);
+  if (forLocale) {
+    redirect(`/${locale}/blog/${forLocale.slug}`);
+  }
+
+  redirect(`/${hint.language}/blog/${hint.slug}`);
+}

--- a/apps/web/src/sanity/lib/queries.js
+++ b/apps/web/src/sanity/lib/queries.js
@@ -90,6 +90,18 @@ export const postBySlugQuery = groq`
   }
 `;
 
+// Post por slug en cualquier idioma (solo metadatos para resolver URL canónica)
+export const postBySlugAnyLanguageQuery = groq`
+  *[_type == "post" && slug.current == $slug][0] {
+    language,
+    "slug": slug.current,
+    "_translations": *[_type == "translation.metadata" && references(^._id)].translations[].value->{
+      "slug": slug.current,
+      language
+    }
+  }
+`;
+
 // Obtener posts por categoría
 export const postsByCategoryQuery = groq`
   *[_type == "post" && $categorySlug in categories[]->slug.current && language == $language] | order(publishedAt desc) {

--- a/apps/web/src/sanity/lib/queries.js
+++ b/apps/web/src/sanity/lib/queries.js
@@ -30,9 +30,9 @@ export const allPostsQuery = groq`
   }
 `;
 
-// Obtener un post por slug
+// Obtener un post por slug e idioma
 export const postBySlugQuery = groq`
-  *[_type == "post" && slug.current == $slug][0] {
+  *[_type == "post" && slug.current == $slug && language == $language][0] {
     _id,
     title,
     slug,

--- a/apps/web/src/sanity/lib/queries.js
+++ b/apps/web/src/sanity/lib/queries.js
@@ -30,12 +30,13 @@ export const allPostsQuery = groq`
   }
 `;
 
-// Obtener un post por slug e idioma
+// Obtener un post por slug e idioma, con traducciones para el language switcher
 export const postBySlugQuery = groq`
   *[_type == "post" && slug.current == $slug && language == $language][0] {
     _id,
     title,
     slug,
+    language,
     publishedAt,
     excerpt,
     body[] {
@@ -81,6 +82,10 @@ export const postBySlugQuery = groq`
     "categories": categories[]->{
       title,
       slug
+    },
+    "_translations": *[_type == "translation.metadata" && references(^._id)].translations[].value->{
+      "slug": slug.current,
+      language
     }
   }
 `;

--- a/apps/web/src/styles/_font-variables.scss
+++ b/apps/web/src/styles/_font-variables.scss
@@ -1,46 +1,52 @@
 @font-face {
 	font-family: "popBlack";
 	src: url("/fonts/pop_black.ttf");
+	font-display: swap;
 }
 @font-face {
 	font-family: "popBold";
 	src: url("/fonts/pop_bold.ttf");
+	font-display: swap;
 }
 @font-face {
 	font-family: "popExtraBold";
 	src: url("/fonts/pop_extrabold.ttf");
+	font-display: swap;
 }
 @font-face {
 	font-family: "popExtLig";
 	src: url("/fonts/pop_extralight.ttf");
+	font-display: swap;
 }
 @font-face {
 	font-family: "popLig";
 	src: url("/fonts/pop_light.ttf");
+	font-display: swap;
 }
 @font-face {
 	font-family: "popMed";
 	src: url("/fonts/pop_medium.ttf");
+	font-display: swap;
 }
 @font-face {
 	font-family: "popReg";
 	src: url("/fonts/pop_regular.ttf");
+	font-display: swap;
 }
 @font-face {
 	font-family: "popThin";
 	src: url("/fonts/pop_thin.ttf");
-
+	font-display: swap;
 }
 @font-face {
 	font-family: "popRare";
 	src: url("/fonts/yesteryear.ttf");
-
+	font-display: swap;
 }
-
 @font-face {
 	font-family: "popHomeMade";
 	src: url("/fonts/apple_homemade.ttf");
-
+	font-display: swap;
 }
 
 

--- a/apps/web/tailwind.config.js
+++ b/apps/web/tailwind.config.js
@@ -92,6 +92,20 @@ module.exports = {
           pressed: 'var(--interactive-inverse-pressed, #4A41A5)',
           disabled: 'var(--interactive-inverse-disabled, #8F8F8F)',
         },
+        keyframes: {
+          fadeIn: {
+            '0%': { opacity: '0' },
+            '100%': { opacity: '1' },
+          },
+          zoomIn: {
+            '0%': { transform: 'scale(0.5)' },
+            '100%': { transform: 'scale(1)' },
+          },
+        },
+        animation: {
+          'fade-in': 'fadeIn 1s ease-out both',
+          'zoom-in': 'zoomIn 1s ease-out both',
+        },
         border: {
           DEFAULT: 'var(--border-default, #D8D8D2)',
           subdued: 'var(--border-subdued, #E4E4E0)',


### PR DESCRIPTION
Cambios
1. apps/web/src/sanity/lib/queries.js
Nueva consulta postBySlugAnyLanguageQuery: localiza un post por slug.current sin filtrar por idioma y trae language, slug y _translations (misma forma que en el post completo).
2. apps/web/src/lib/resolveBlogPost.js
resolveBlogPost(slug, locale): primero intenta el post con slug + idioma; si no hay resultado, usa la consulta anterior.
Si el slug corresponde a otro idioma y existe traducción al locale de la URL → redirect a /${locale}/blog/${slugTraducido}.
Si no hay traducción al idioma pedido → redirect a la URL canónica del documento (/${idiomaDelPost}/blog/...).
Caso raro hint.language === locale pero el primer fetch falló → reintento con fetchPost antes de devolver null.
3. apps/web/app/[locale]/blog/[slug]/page.js
generateMetadata y la página usan resolveBlogPost en lugar de getPost directo.
4. apps/web/middleware.js
Función isBlogArticlePath: rutas con forma /[locale]/blog/[slug] (tres segmentos).
La redirección por cookie NEXT_LOCALE que cambiaba el prefijo de idioma no se aplica en esas rutas, para no convertir /en/blog/slug-en-inglés en /es/blog/mismo-slug (que rompía la URL antes de que el servidor pudiera redirigir bien).